### PR TITLE
improv: Remove useless statements from profiling

### DIFF
--- a/deirokay/statements/not_null.py
+++ b/deirokay/statements/not_null.py
@@ -50,6 +50,12 @@ class NotNull(BaseStatement):
         }
 
         at_least_perc = float(100.0*not_nulls.sum()/len(not_nulls))
+
+        if at_least_perc == 0.0:
+            raise NotImplementedError(
+                'Statement is useless when all rows are null.'
+            )
+
         if at_least_perc != 100.0:
             statement['at_least_%'] = at_least_perc
 

--- a/deirokay/statements/unique.py
+++ b/deirokay/statements/unique.py
@@ -35,8 +35,14 @@ class Unique(BaseStatement):
             'type': 'unique',
         }
 
-        at_leat_perc = float(100.0*unique.sum()/len(unique))
-        if at_leat_perc != 100.0:
-            statement['at_least_%'] = at_leat_perc
+        at_least_perc = float(100.0*unique.sum()/len(unique))
+
+        if at_least_perc == 0.0:
+            raise NotImplementedError(
+                'Statement is useless when all rows are not unique.'
+            )
+
+        if at_least_perc != 100.0:
+            statement['at_least_%'] = at_least_perc
 
         return statement

--- a/tests/statements/test_not_null.py
+++ b/tests/statements/test_not_null.py
@@ -1,4 +1,6 @@
-from deirokay import data_reader, validate
+from pprint import pprint
+
+from deirokay import data_reader, profile, validate
 
 
 def test_not_null_statement():
@@ -32,3 +34,23 @@ def test_not_null_statement():
     }
 
     validate(df, against=assertions)
+
+
+def test_profile_wont_generate_useless_statement():
+    """Prevent statement generation when `at_least_%` is 0."""
+    df = data_reader(
+        'tests/transactions_sample.csv',
+        options='tests/options.json'
+    )
+
+    validation_doc = profile(df, 'sample')
+    pprint(validation_doc)
+
+    # Check that the statement was not generated for "EMPTY" column
+    scope_empty = next(filter(
+        lambda x: x['scope'] == 'EMPTY', validation_doc['items']
+    ))
+    assert len([
+        stmt for stmt in scope_empty['statements']
+        if stmt['type'] == 'not_null'
+    ]) == 0

--- a/tests/statements/test_unique.py
+++ b/tests/statements/test_unique.py
@@ -1,0 +1,24 @@
+from pprint import pprint
+from deirokay import data_reader, profile
+
+
+def test_profile_wont_generate_useless_statement():
+    """Prevent statement generation when `at_least_%` is 0."""
+    df = data_reader(
+        'tests/transactions_sample.csv',
+        options='tests/options.json'
+    )
+
+    validation_doc = profile(df, 'sample')
+    pprint(validation_doc)
+
+    # Check that the statement was not generated for
+    # "DT_OPERACAO01" column
+    scope_empty = next(filter(
+        lambda x: x['scope'] == 'DT_OPERACAO01',
+        validation_doc['items']
+    ))
+    assert len([
+        stmt for stmt in scope_empty['statements']
+        if stmt['type'] == 'unique'
+    ]) == 0

--- a/tests/test_data_profiling.py
+++ b/tests/test_data_profiling.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 from deirokay import data_reader, profile, validate
 
 
@@ -9,4 +11,6 @@ def test_profiling():
     )
 
     validation_document = profile(df, 'transactions_sample')
+    pprint(validation_document)
+
     validate(df, against=validation_document)


### PR DESCRIPTION
Remove useless statements from validation document generated by `profile`.

Ex: `unique` statement with `at_least_%: 0.0`