### PR TITLE
docs: Fix API reference

### DIFF
--- a/docs/source/api-reference/index.rst
+++ b/docs/source/api-reference/index.rst
@@ -7,4 +7,4 @@ API Reference
       :template: custom-module-template.rst
       :recursive:
 
-    deirokay
+      deirokay


### PR DESCRIPTION
API Reference docs now should be properly generated by Sphinx.