### PR TITLE
feat: Rewords list-like alias requirement exception

### DIFF
--- a/deirokay/history_template.py
+++ b/deirokay/history_template.py
@@ -96,8 +96,9 @@ class DocumentNode():
             attributes = set(DocumentNode.attribute_keys.input(docs).all())
         except TypeError:
             raise TypeError(
-                'List-like scopes must be aliased when using `series`'
-                ' templates. Make sure your last Deirokay logs obey this rule.'
+                'Every list-like scope must be aliased'
+                ' when some scope uses `series` templates.'
+                ' Make sure your last Deirokay logs obey this rule.'
             )
 
         for att in attributes:

--- a/deirokay/history_template.py
+++ b/deirokay/history_template.py
@@ -96,8 +96,8 @@ class DocumentNode():
             attributes = set(DocumentNode.attribute_keys.input(docs).all())
         except TypeError:
             raise TypeError(
-                'Every list-like scope must be aliased'
-                ' when some scope uses `series` templates.'
+                'All list-like scopes must be aliased'
+                ' when some statement uses the `series` template.'
                 ' Make sure your last Deirokay logs obey this rule.'
             )
 


### PR DESCRIPTION
Provides better explanation when user does not provide an alias for some list-like scope, but one of the scopes uses series templates.